### PR TITLE
Feature/configurable api

### DIFF
--- a/launchcontainer/launchcontainer.py
+++ b/launchcontainer/launchcontainer.py
@@ -18,7 +18,10 @@ from xblock.fragment import Fragment
 log = logging.getLogger(__name__)
 
 
-API_URL_DEFAULT = 'http://isc.appsembler.com/isc/newdeploy'  # BBB
+try:
+    API_URL_DEFAULT = settings.ENV_TOKENS.get('LAUNCHCONTAINER_API_CONF', None)['default'],
+except TypeError:
+    API_URL_DEFAULT = 'http://isc.appsembler.com/isc/newdeploy'  # BBB
 
 
 class LaunchContainerXBlock(XBlock):
@@ -49,7 +52,7 @@ class LaunchContainerXBlock(XBlock):
     )
 
     api_url = String(
-        default=u'',
+        default=API_URL_DEFAULT,
         scope=Scope.content,
     )
 
@@ -67,13 +70,10 @@ class LaunchContainerXBlock(XBlock):
 
     def _get_API_url(self):
         api_conf = settings.ENV_TOKENS.get('LAUNCHCONTAINER_API_CONF', None)
-        if not api_conf:
-            return API_URL_DEFAULT  # BBB
-        else:
-            try:
-                return api_conf[self.block_course_org]
-            except KeyError:
-                return api_conf['default']
+        try:
+            return api_conf[self.block_course_org]
+        except (TypeError, KeyError):
+            return API_URL_DEFAULT
 
     def student_view(self, context=None):
         """

--- a/launchcontainer/launchcontainer.py
+++ b/launchcontainer/launchcontainer.py
@@ -18,7 +18,7 @@ from xblock.fragment import Fragment
 log = logging.getLogger(__name__)
 
 
-API_URL_DEFAULT = 'http://isc.appsembler.com'  # BBB
+API_URL_DEFAULT = 'http://isc.appsembler.com/isc/newdeploy'  # BBB
 
 
 class LaunchContainerXBlock(XBlock):
@@ -57,6 +57,14 @@ class LaunchContainerXBlock(XBlock):
     def block_course_org(self):
         return self.runtime.course_id.org
     
+    @property
+    def student_email(self):
+        if hasattr(self, "runtime"):
+            user = self.runtime._services['user'].get_current_user()
+            return user.emails[0]
+        else:
+            return None
+
     def _get_API_url(self):
         api_conf = settings.ENV_TOKENS.get('LAUNCHCONTAINER_API_CONF', None)
         if not api_conf:
@@ -72,20 +80,11 @@ class LaunchContainerXBlock(XBlock):
         The primary view of the LaunchContainerXBlock, shown to students
         when viewing courses.
         """
-        user_email = None
-        # workbench runtime won't supply system property
-        if getattr(self, 'system', None):
-            if self.system.anonymous_student_id:
-                if getattr(self.system, 'get_real_user', None):
-                    anon_id = self.system.anonymous_student_id
-                    user = self.system.get_real_user(anon_id)
-                    if user and user.is_authenticated():
-                        user_email = user.email
         
         context = {
             'project': self.project,
             'project_friendly': self.project_friendly,
-            'user_email' : user_email,
+            'user_email' : self.student_email,
             'API_url': self.api_url
         }
         frag = Fragment()

--- a/launchcontainer/launchcontainer.py
+++ b/launchcontainer/launchcontainer.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 
 
 try:
-    API_URL_DEFAULT = settings.ENV_TOKENS.get('LAUNCHCONTAINER_API_CONF', None)['default'],
+    API_URL_DEFAULT = settings.ENV_TOKENS.get('LAUNCHCONTAINER_API_CONF', None)['default']
 except TypeError:
     API_URL_DEFAULT = 'http://isc.appsembler.com/isc/newdeploy'  # BBB
 

--- a/launchcontainer/static/html/launchcontainer.html
+++ b/launchcontainer/static/html/launchcontainer.html
@@ -1,5 +1,5 @@
 <div id="launcher1">
-    <iframe src="https://isc.appsembler.com/isc/newdeploy/" style="visibility: hidden" width="0" height="0"></iframe>
+    <iframe src="{{ API_url }}" style="visibility: hidden" width="0" height="0"></iframe>
     <p>When you click the button below, a new {{ project_friendly }} site will be started for you.</p>
     <input type="button" value="Launch {{ project_friendly }} site" style="margin-bottom: 20px;" />
 </div>

--- a/launchcontainer/static/js/src/launchcontainer.js
+++ b/launchcontainer/static/js/src/launchcontainer.js
@@ -1,22 +1,33 @@
-$(document).ready(
-  function () {
-    var $launcher = $('#launcher1'), $launch_button = $launcher.find('input');
-    $launch_button.click(function() {
-        console.log('Clicked launch button');
-        $launch_button.attr('disabled', 'disabled').val('Launching...');
-        $launcher.find('iframe')[0].contentWindow.postMessage({
-            owner_email: "{{ user_email }}",
-            project: "{{ project }}"
-        }, "https://isc.appsembler.com");
-        return false;
-    });
-    window.addEventListener("message", function (event) {
-        if (event.origin !== 'https://isc.appsembler.com') return;
-        if(event.data.status === 'siteDeployed') {
-            $launcher.html(event.data.html_content);
-        } else if(event.data.status === 'deploymentError') {
-            $launcher.text(event.data.error_message);
-        }
-    }, false);
-});
+function getURLOrigin(path) {
+    var link = document.createElement('a');
+    link.setAttribute('href', path);
 
+    port = (link.port) ? ':'+link.port : '';
+    return link.protocol + '//' + link.hostname + port;
+}
+
+function LaunchContainerXBlock(runtime, element) {
+
+    $(document).ready(
+      function () {
+        var $launcher = $('#launcher1'), $launch_button = $launcher.find('input');
+        $launch_button.click(function() {
+            console.log('Clicked launch button');
+            $launch_button.attr('disabled', 'disabled').val('Launching...');
+            $launcher.find('iframe')[0].contentWindow.postMessage({
+                owner_email: "{{ user_email }}",
+                project: "{{ project }}"
+            }, "{{ API_url }}");
+            return false;
+        });
+        window.addEventListener("message", function (event) {
+            if (event.origin !== getURLOrigin('{{ API_url }}')) return;
+            if(event.data.status === 'siteDeployed') {
+                $launcher.html(event.data.html_content);
+            } else if(event.data.status === 'deploymentError') {
+                $launcher.text(event.data.error_message);
+            }
+        }, false);
+    });
+
+}

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-launchcontainer',
-    version='1.1',
+    version='1.1.1',
     author='Bryan Wilson, Jazkarta',
     description=('Open EdX XBlock to display a button allowing an LMS user '
                  'to launch and link to an external courseware resource via the '

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,11 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-launchcontainer',
-    version='0.1',
-    author='Bryan Wilson, Jazkarta',
+    version='0.2',
+    author='Bryan Wilson, Appsembler',
     description=('Open EdX XBlock to display a button allowing an LMS user '
                  'to launch and link to an external courseware resource via the '
-                 'Appsembler Intersystems  API'),
+                 'Wharf container API'),
     packages=[
         'launchcontainer',
     ],


### PR DESCRIPTION
Adds ability to specify a different API endpoint URL per org from a dictionary in ENV_TOKENS.  API URL is stored in a field on the XBlock instance but is not editable because we don't want Studio end users changing it.   You can specify a `'default'` key for a site-wide API URL.  If none is found by the XBlock view, and a site-wide default is not specified, will fall back to a package default of "http://isc.appsembler.com/isc/newdeploy".  
